### PR TITLE
Convert service to RabbitMQ consumer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ tests/__pycache__/
 __pycache__
 logs/
 *.pyc
+.Python
+bin/
+lib/
+include/
+pip-selfcheck.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM onsdigital/flask-crypto
 
-ADD server.py /app/server.py
+ADD consumer.py /app/consumer.py
 ADD settings.py /app/settings.py
 ADD requirements.txt /app/requirements.txt
 
@@ -9,8 +9,6 @@ RUN mkdir -p /app/logs
 # set working directory to /app/
 WORKDIR /app/
 
-EXPOSE 5001
-
 RUN pip3 install --no-cache-dir -U -I -r /app/requirements.txt
 
-ENTRYPOINT python3 server.py
+ENTRYPOINT python3 consumer.py

--- a/consumer.py
+++ b/consumer.py
@@ -1,0 +1,23 @@
+import pika
+import os
+import logging
+import sys
+import settings
+
+logging.basicConfig(stream=sys.stdout, level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
+
+logging.debug("Starting survey-notification consumer..")
+
+def on_message(channel, method_frame, header_frame, body):
+    logging.debug( method_frame.delivery_tag )
+    logging.debug( body )
+    channel.basic_ack(delivery_tag=method_frame.delivery_tag)
+
+connection = pika.BlockingConnection(pika.URLParameters(settings.RABBIT_URL))
+channel = connection.channel()
+channel.basic_consume(on_message, settings.RABBIT_QUEUE)
+try:
+    channel.start_consuming()
+except KeyboardInterrupt:
+    channel.stop_consuming()
+connection.close()

--- a/consumer.py
+++ b/consumer.py
@@ -11,8 +11,11 @@ logging.debug("Starting survey-notification consumer..")
 
 def get_survey_from_store(mongoid):
     store_url = settings.SDX_STORE_URL + "/responses/" + mongoid
-    result = requests.get(store_url).text
-    logging.debug(result)
+    result = requests.get(store_url).json()
+    stored_json = result['survey_response']
+    transform_url = settings.SDX_TRANSFORM_CS_URL + "/pck"
+    transformed_data = requests.post(transform_url, json=stored_json)
+    logging.debug(transformed_data.text)
 
 def on_message(channel, method_frame, header_frame, body):
     logging.debug( method_frame.delivery_tag )

--- a/consumer.py
+++ b/consumer.py
@@ -56,15 +56,18 @@ def get_survey_from_store(mongoid):
 
 
 def on_message(channel, method_frame, header_frame, body):
-    logging.debug( method_frame.delivery_tag )
+    logging.debug(method_frame.delivery_tag)
     get_survey_from_store(body.decode("utf-8"))
     channel.basic_ack(delivery_tag=method_frame.delivery_tag)
 
 connection = pika.BlockingConnection(pika.URLParameters(settings.RABBIT_URL))
 channel = connection.channel()
+channel.queue_declare(queue=settings.RABBIT_QUEUE)
 channel.basic_consume(on_message, settings.RABBIT_QUEUE)
+
 try:
     channel.start_consuming()
 except KeyboardInterrupt:
     channel.stop_consuming()
+
 connection.close()

--- a/consumer.py
+++ b/consumer.py
@@ -1,5 +1,4 @@
 import pika
-import os
 import io
 import logging
 import sys
@@ -12,18 +11,22 @@ logging.basicConfig(stream=sys.stdout, level=settings.LOGGING_LEVEL, format=sett
 
 logging.debug("Starting survey-notification consumer..")
 
+
 def connect_to_ftp():
     ftp = FTP(settings.FTP_HOST)
     ftp.login(user=settings.FTP_USER, passwd=settings.FTP_PASS)
     return ftp
 
+
 def deliver_ascii_to_ftp(ftp, filename, data):
     stream = io.StringIO(data)
     ftp.storlines('STOR ' + filename, stream)
 
+
 def deliver_binary_to_ftp(ftp, filename, data):
     stream = io.BytesIO(data)
     ftp.storbinary('STOR ' + filename, stream)
+
 
 def get_survey_from_store(mongoid):
     store_url = settings.SDX_STORE_URL + "/responses/" + mongoid
@@ -35,7 +38,7 @@ def get_survey_from_store(mongoid):
     zip_contents = transformed_data.content
 
     try:
-        z=zipfile.ZipFile(io.BytesIO(zip_contents))
+        z = zipfile.ZipFile(io.BytesIO(zip_contents))
         logging.debug("Zip contents:")
         logging.debug(z.namelist())
         ftp = connect_to_ftp()
@@ -50,6 +53,7 @@ def get_survey_from_store(mongoid):
     except (RuntimeError, zipfile.BadZipfile):
         logging.debug("Bad zip file!")
         # TODO: Need to deal with exception
+
 
 def on_message(channel, method_frame, header_frame, body):
     logging.debug( method_frame.delivery_tag )

--- a/consumer.py
+++ b/consumer.py
@@ -3,14 +3,20 @@ import os
 import logging
 import sys
 import settings
+import requests
 
 logging.basicConfig(stream=sys.stdout, level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
 
 logging.debug("Starting survey-notification consumer..")
 
+def get_survey_from_store(mongoid):
+    store_url = settings.SDX_STORE_URL + "/responses/" + mongoid
+    result = requests.get(store_url).text
+    logging.debug(result)
+
 def on_message(channel, method_frame, header_frame, body):
     logging.debug( method_frame.delivery_tag )
-    logging.debug( body )
+    get_survey_from_store(body.decode("utf-8"))
     channel.basic_ack(delivery_tag=method_frame.delivery_tag)
 
 connection = pika.BlockingConnection(pika.URLParameters(settings.RABBIT_URL))

--- a/consumer.py
+++ b/consumer.py
@@ -1,21 +1,55 @@
 import pika
 import os
+import io
 import logging
 import sys
 import settings
 import requests
+import zipfile
+from ftplib import FTP
 
 logging.basicConfig(stream=sys.stdout, level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
 
 logging.debug("Starting survey-notification consumer..")
 
+def connect_to_ftp():
+    ftp = FTP(settings.FTP_HOST)
+    ftp.login(user=settings.FTP_USER, passwd=settings.FTP_PASS)
+    return ftp
+
+def deliver_ascii_to_ftp(ftp, filename, data):
+    stream = io.StringIO(data)
+    ftp.storlines('STOR ' + filename, stream)
+
+def deliver_binary_to_ftp(ftp, filename, data):
+    stream = io.BytesIO(data)
+    ftp.storbinary('STOR ' + filename, stream)
+
 def get_survey_from_store(mongoid):
     store_url = settings.SDX_STORE_URL + "/responses/" + mongoid
     result = requests.get(store_url).json()
     stored_json = result['survey_response']
-    transform_url = settings.SDX_TRANSFORM_CS_URL + "/pck"
+
+    transform_url = settings.SDX_TRANSFORM_CS_URL + "/common-software"
     transformed_data = requests.post(transform_url, json=stored_json)
-    logging.debug(transformed_data.text)
+    zip_contents = transformed_data.content
+
+    try:
+        z=zipfile.ZipFile(io.BytesIO(zip_contents))
+        logging.debug("Zip contents:")
+        logging.debug(z.namelist())
+        ftp = connect_to_ftp()
+        for filename in z.namelist():
+            if filename.endswith('/'):
+                continue
+            logging.debug("Processing file from zip: " + filename)
+            edc_file = z.open(filename)
+            deliver_binary_to_ftp(ftp, filename, edc_file.read())
+        ftp.quit()
+
+    except (RuntimeError, zipfile.BadZipfile):
+        logging.debug("Bad zip file!")
+        # TODO: Need to deal with exception
 
 def on_message(channel, method_frame, header_frame, body):
     logging.debug( method_frame.delivery_tag )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-Flask==0.10.1
-itsdangerous==0.24
-Jinja2==2.8
-MarkupSafe==0.23
-Werkzeug==0.11.9
 requests==2.10.0
+pika==0.10.0

--- a/server.py
+++ b/server.py
@@ -1,15 +1,14 @@
 import settings
-import json
-import html
 import logging
 import logging.handlers
 import requests
-from flask import Flask, request, Response
+from flask import Flask
 
 app = Flask(__name__)
 
 app.config['SDX_STORE_URL'] = settings.SDX_STORE_URL
 app.config['SDX_TRANSFORM_CS_URL'] = settings.SDX_TRANSFORM_CS_URL
+
 
 @app.route('/pck', methods=['GET'])
 def do_transform_pck():
@@ -21,6 +20,7 @@ def do_transform_pck():
     transformed_data = requests.post(transform_url, json=stored_json)
     return(transformed_data.text)
 
+
 @app.route('/html', methods=['GET'])
 def do_transform_html():
     store_url = app.config['SDX_STORE_URL'] + "/response?surveyId=023"
@@ -30,6 +30,7 @@ def do_transform_html():
     transform_url = app.config['SDX_TRANSFORM_CS_URL'] + "/html"
     transformed_data = requests.post(transform_url, json=stored_json)
     return(transformed_data.text)
+
 
 @app.route('/idbr', methods=['GET'])
 def do_transform_idbr():

--- a/settings.py
+++ b/settings.py
@@ -18,7 +18,7 @@ FTP_HOST = os.getenv('FTP_HOST', 'pure-ftpd')
 FTP_USER = os.getenv('FTP_USER')
 FTP_PASS = os.getenv('FTP_PASS')
 
-RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'survey-notifications')
+RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'sdx-survey-notifications')
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),

--- a/settings.py
+++ b/settings.py
@@ -20,10 +20,12 @@ FTP_PASS = os.getenv('FTP_PASS')
 
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'sdx-survey-notifications')
 
-RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
+RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}?connection_attempts={connection_attempts}&retry_delay={retry_delay}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),
     port=os.getenv('RABBITMQ_PORT', 5672),
     user=os.getenv('RABBITMQ_DEFAULT_USER', 'rabbit'),
     password=os.getenv('RABBITMQ_DEFAULT_PASS', 'rabbit'),
-    vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
+    vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f'),
+    connection_attempts=os.getenv('RABBITMQ_DEFAULT_CONN_ATTEMPTS', 5),
+    retry_delay=os.getenv('RABBITMQ_DEFAULT_RETRY_DELAY', 5)
 )

--- a/settings.py
+++ b/settings.py
@@ -7,6 +7,23 @@ LOGGING_FORMAT = "%(asctime)s|%(levelname)s: %(message)s"
 LOGGING_LOCATION = "logs/downstream.log"
 LOGGING_LEVEL = logging.DEBUG
 
+APP_ROOT = os.path.dirname(os.path.abspath(__file__))
+APP_TMP = os.path.join(APP_ROOT, 'tmp')
+
 # Default to true, cast to boolean
-SDX_STORE_URL = os.getenv("SDX_STORE_URL", "http://localhost:8080")
-SDX_TRANSFORM_CS_URL = os.getenv("SDX_TRANSFORM_CS_URL", "http://localhost:5000")
+SDX_STORE_URL = os.getenv("SDX_STORE_URL", "http://localhost:5000")
+SDX_TRANSFORM_CS_URL = os.getenv("SDX_TRANSFORM_CS_URL", "http://localhost:5002")
+
+FTP_HOST = os.getenv('FTP_HOST', 'pure-ftpd')
+FTP_USER = os.getenv('FTP_USER')
+FTP_PASS = os.getenv('FTP_PASS')
+
+RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'survey-notifications')
+
+RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
+    hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),
+    port=os.getenv('RABBITMQ_PORT', 5672),
+    user=os.getenv('RABBITMQ_DEFAULT_USER', 'rabbit'),
+    password=os.getenv('RABBITMQ_DEFAULT_PASS', 'rabbit'),
+    vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
+)


### PR DESCRIPTION
sdx-downstream is now driven from a notification queue (sdx-survey-notifications) that gets appended to when a survey is stored in sdx-store.

**Changes**

- Convert Flask app to a RabbitMQ consumer
- Consume notifications from sdx-survey-notifications queue and:
  * Get survey JSON from sdx-store service
  * Get transformed data as a zip from the sdx-transform-cs service
  * Put the contents of the zip on the FTP server

**How to test**

- Use the docker-compose setup from the dockers repo
- POST this JSON to `http://<docker_host>:85/responses`:
```
{
   "type": "uk.gov.ons.edc.eq:surveyresponse",
   "origin": "uk.gov.ons.edc.eq",
   "survey_id": "023",
   "version": "0.0.1",
   "collection": {
     "exercise_sid": "hfjdskf",
     "instrument_id": "0203",
     "period": "0216"
   },
   "submitted_at": "2016-03-12T10:39:40Z",
   "metadata": {
     "user_id": "789473423",
     "ru_ref": "12345678901A"
   },
   "data": {
     "11": "01/04/2016",
     "12": "31/10/2016",
     "20": "1800000",
     "51": "84",
     "52": "10",
     "53": "73",
     "54": "24",
     "50": "205",
     "22": "705000",
     "23": "900",
     "24": "74",
     "25": "50",
     "26": "100",
     "21": "60000",
     "27": "7400",
     "146": "some comment"
   }
}
```
- Start sdx-downstream - `docker-compose start sdx-downstream`
- Check the contents of the FTP 

**Depends on**
https://github.com/ONSdigital/dockers/pull/10
https://github.com/ONSdigital/sdx-store/pull/2

**Who can test**

Anyone but @ajmaddaford