### PR TITLE
Correct non-structlog logger usage

### DIFF
--- a/app/async_consumer.py
+++ b/app/async_consumer.py
@@ -94,8 +94,8 @@ class AsyncConsumer(object):
         if self._closing:
             self._connection.ioloop.stop()
         else:
-            LOGGER.warning('Connection closed, reopening in 5 seconds: (%s) %s',
-                           reply_code, reply_text)
+            LOGGER.warning('Connection closed, reopening in 5 seconds',
+                           reply_code=reply_code, reply_text=reply_text)
             self._connection.add_timeout(5, self.reconnect)
 
     def on_connection_open(self, unused_connection):

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -6,9 +6,7 @@ from app.response_processor import ResponseProcessor
 
 logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
 
-logger = logging.getLogger(__name__)
-
-logger = wrap_logger(logger)
+logger = wrap_logger(logging.getLogger(__name__))
 
 
 class Consumer(AsyncConsumer):

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -1,18 +1,10 @@
-import logging
 from app import settings
 from app.settings import session
 import zipfile
 import io
 import pika
-from structlog import wrap_logger
 from ftplib import FTP
 from requests.packages.urllib3.exceptions import MaxRetryError
-
-logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
-
-logger = logging.getLogger(__name__)
-
-logger = wrap_logger(logger)
 
 
 def connect_to_ftp():
@@ -31,34 +23,32 @@ def deliver_binary_to_ftp(ftp, filename, data):
     ftp.storbinary('STOR ' + filename, stream)
 
 
-def remote_call(request_url, json=None):
-    try:
-        logger.info("Calling service", request_url=request_url)
-
-        r = None
-
-        if json:
-            r = session.post(request_url, json=json)
-        else:
-            r = session.get(request_url)
-
-        return r
-    except MaxRetryError:
-        logger.error("Max retries exceeded (5)", request_url=request_url)
-
-
-def response_ok(res):
-    if res.status_code == 200:
-        logger.info("Returned from service", request_url=res.url, status_code=res.status_code)
-        return True
-    else:
-        logger.error("Returned from service", request_url=res.url, status_code=res.status_code)
-        return False
-
-
 class ResponseProcessor:
     def __init__(self, logger):
         self.logger = logger
+
+    def remote_call(self, request_url, json=None):
+        try:
+            self.logger.info("Calling service", request_url=request_url)
+
+            r = None
+
+            if json:
+                r = session.post(request_url, json=json)
+            else:
+                r = session.get(request_url)
+
+            return r
+        except MaxRetryError:
+            self.logger.error("Max retries exceeded (5)", request_url=request_url)
+
+    def response_ok(self, res):
+        if res.status_code == 200:
+            self.logger.info("Returned from service", request_url=res.url, status_code=res.status_code)
+            return True
+        else:
+            self.logger.error("Returned from service", request_url=res.url, status_code=res.status_code)
+            return False
 
     def process(self, mongoid):
         processed_ok = False
@@ -66,9 +56,8 @@ class ResponseProcessor:
 
         if survey_response:
             metadata = survey_response['metadata']
-
             # Update consumers logger to use bound vars
-            self.logger = logger.bind(user_id=metadata['user_id'], ru_ref=metadata['ru_ref'])
+            self.logger = self.logger.bind(user_id=metadata['user_id'], ru_ref=metadata['ru_ref'])
             sequence_no = self.get_sequence_no()
 
         if survey_response and sequence_no:
@@ -95,12 +84,9 @@ class ResponseProcessor:
         """
         store_url = settings.SDX_STORE_URL + "/responses/" + mongoid
 
-        r = remote_call(store_url)
+        r = self.remote_call(store_url)
 
-        if r.status_code == 200:
-            logger.info("Store retrieval success", request_url=r.url)
-        else:
-            logger.info("Store retrieval failed", request_url=r.url, status_code=r.status_code)
+        if not self.response_ok(r):
             return False
 
         result = r.json()
@@ -110,9 +96,9 @@ class ResponseProcessor:
     def get_sequence_no(self):
         sequence_url = settings.SDX_SEQUENCE_URL + "/sequence"
 
-        r = remote_call(sequence_url)
+        r = self.remote_call(sequence_url)
 
-        if not response_ok(r):
+        if not self.response_ok(r):
             return False
 
         result = r.json()
@@ -120,18 +106,18 @@ class ResponseProcessor:
 
     def transform_cs(self, sequence_no, survey_response):
         transform_url = "%s/common-software/%d" % (settings.SDX_TRANSFORM_CS_URL, sequence_no)
-        r = remote_call(transform_url, json=survey_response)
+        r = self.remote_call(transform_url, json=survey_response)
 
-        if not response_ok(r):
+        if not self.response_ok(r):
             return False
 
         return r.content
 
     def transform_xml(self, survey_response):
         transform_url = "%s/xml" % (settings.SDX_TRANSFORM_TESTFORM_URL)
-        r = remote_call(transform_url, json=survey_response)
+        r = self.remote_call(transform_url, json=survey_response)
 
-        if not response_ok(r):
+        if not self.response_ok(r):
             return False
 
         return r.content
@@ -144,12 +130,12 @@ class ResponseProcessor:
         """
         try:
             z = zipfile.ZipFile(io.BytesIO(zip_contents))
-            logger.debug("Unzipped contents", filelist=z.namelist())
+            self.logger.debug("Unzipped contents", filelist=z.namelist())
             ftp = connect_to_ftp()
             for filename in z.namelist():
                 if filename.endswith('/'):
                     continue
-                logger.debug("Processing file from zip", filename=filename)
+                self.logger.debug("Processing file from zip", filename=filename)
                 edc_file = z.open(filename)
                 deliver_binary_to_ftp(ftp, filename, edc_file.read())
             ftp.quit()
@@ -166,7 +152,7 @@ class ResponseProcessor:
 
         """
         try:
-            self.logging.debug("XML Queueing Start")
+            self.logger.debug("XML Queueing Start")
             connection = pika.BlockingConnection(pika.URLParameters(settings.RABBIT_URL))
             channel = connection.channel()
             channel.queue_declare(queue=settings.RABBIT_QUEUE_TESTFORM)
@@ -174,7 +160,7 @@ class ResponseProcessor:
                                   properties=pika.BasicProperties(content_type='application/xml'),
                                   routing_key=settings.RABBIT_QUEUE_TESTFORM,
                                   body=survey_xml)
-            self.logging.debug("XML Queuing Success")
+            self.logger.debug("XML Queuing Success")
             connection.close()
             return True
         except:

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -3,7 +3,9 @@ import logging
 import json
 from unittest.mock import MagicMock
 from app.response_processor import ResponseProcessor
-logger = logging.getLogger(__name__)
+from structlog import wrap_logger
+
+logger = wrap_logger(logging.getLogger(__name__))
 
 
 class TestResponseProcessor(unittest.TestCase):


### PR DESCRIPTION
**Changes**

Remove string replacement in logger calls.

**How to test**

Shutdown rabbit whilst in a compose setup and observe if downstream crashes as reported in #6.

**Who can test**

Anyone but @iwootten