### PR TITLE
route surveys marked heartbeat to different ftp folder

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -20,6 +20,9 @@ FTP_HOST = os.getenv('FTP_HOST', 'pure-ftpd')
 FTP_USER = os.getenv('FTP_USER')
 FTP_PASS = os.getenv('FTP_PASS')
 
+FTP_FOLDER = os.getenv('FTP_FOLDER', '/')
+FTP_HEARTBEAT_FOLDER = os.getenv('FTP_HEARTBEAT_FOLDER', '/heartbeat')
+
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'sdx-survey-notifications')
 RABBIT_QUEUE_TESTFORM = os.getenv('RABBIT_QUEUE_TESTFORM', 'sdx-testform')
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,50 @@
+survey_no_heartbeat = '''
+{
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "origin": "uk.gov.ons.edc.eq",
+  "survey_id": "194825",
+  "version": "0.0.1",
+  "collection": {
+    "exercise_sid": "hfjdskf",
+    "instrument_id": "10",
+    "period": "0616"
+  },
+  "submitted_at": "2016-03-12T10:39:40Z",
+  "metadata": {
+    "user_id": "789473423",
+    "ru_ref": "1234570071A"
+  },
+  "data": {
+    "1": "2",
+    "2": "4",
+    "3": "2",
+    "4": "Y"
+  }
+}
+'''
+
+survey_heartbeat_true = '''
+{
+  "heartbeat": true,
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "origin": "uk.gov.ons.edc.eq",
+  "survey_id": "194825",
+  "version": "0.0.1",
+  "collection": {
+    "exercise_sid": "hfjdskf",
+    "instrument_id": "10",
+    "period": "0616"
+  },
+  "submitted_at": "2016-03-12T10:39:40Z",
+  "metadata": {
+    "user_id": "789473423",
+    "ru_ref": "1234570071A"
+  },
+  "data": {
+    "1": "2",
+    "2": "4",
+    "3": "2",
+    "4": "Y"
+  }
+}
+'''


### PR DESCRIPTION
**Changes**
Enables survey submissions to be marked as 'heartbeat' and routed to a different ftp folder, specified in the settings

**How to test**
Requires heartbeat branch of sdx-validate and sdx-compose
Submit survey marked with "heartbeat": true in the json
Should carry out the same process but put the produced files in the '/heartbeat' folder

**Who can test**
Anyone but @elliott-jenkins