### PR TITLE
Fix docker compose link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ The following envioronment variables can be set:
 
 ## Usage
 
-sdx-downstream works as a single consumer which exposes no endpoints. The best way to test its behaviour is to start it within a [docker-compose setup](https://github.com/ONSdigital/dockers) and trigger the consumer through the console.
+sdx-downstream works as a single consumer which exposes no endpoints. The best way to test its behaviour is to start it within a [docker-compose](https://github.com/ONSdigital/sdx-compose) setup and trigger the consumer through the console.


### PR DESCRIPTION
The existing link in the README points to the old dockers repo, this pull request corrects this to point to the new sdx-compose repo.