### PR TITLE
Delayed retries

### DIFF
--- a/app/async_consumer.py
+++ b/app/async_consumer.py
@@ -18,7 +18,7 @@ class AsyncConsumer(object):
     commands that were issued and that should surface in the output as well.
 
     """
-    EXCHANGE = 'message'
+    EXCHANGE = settings.RABBIT_EXCHANGE
     EXCHANGE_TYPE = 'topic'
     QUEUE = settings.RABBIT_QUEUE
 
@@ -229,6 +229,16 @@ class AsyncConsumer(object):
         """
         LOGGER.info('Acknowledging message', delivery_tag=delivery_tag, **kwargs)
         self._channel.basic_ack(delivery_tag)
+
+    def reject_message(self, delivery_tag, **kwargs):
+        """Reject the message delivery from RabbitMQ by sending a
+        Basic.Reject RPC method for the delivery tag.
+
+        :param int delivery_tag: The delivery tag from the Basic.Deliver frame
+
+        """
+        LOGGER.info('Rejecting message', delivery_tag=delivery_tag, **kwargs)
+        self._channel.basic_reject(delivery_tag, requeue=False)
 
     def on_message(self, unused_channel, basic_deliver, properties, body):
         """Invoked by pika when a message is delivered from RabbitMQ. The

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -3,22 +3,60 @@ from app.async_consumer import AsyncConsumer
 from app.helpers.request_helper import get_doc_from_store
 from app.processors.common_software_processor import CommonSoftwareProcessor
 from app.processors.census_processor import CensusProcessor
+from app.queue_publisher import QueuePublisher
+from app import settings
 
 SURVEY_ID_TO_PROCESSOR = {'023': CommonSoftwareProcessor,
                           '0': CensusProcessor}
 
 
+def publish_to_retry_queue(message, count):
+    publisher = QueuePublisher(logger, settings.RABBIT_URLS, settings.RABBIT_DELAY_QUEUE, arguments={
+        'x-message-ttl': settings.QUEUE_RETRY_DELAY_IN_MS,
+        'x-dead-letter-exchange': settings.RABBIT_EXCHANGE,
+        'x-dead-letter-routing-key': settings.RABBIT_QUEUE,
+
+    })
+    return publisher.publish_message(message, headers={'x-delivery-count': count})
+
+
+def get_delivery_count_from_properties(properties):
+    delivery_count = 0
+    if properties.headers and 'x-delivery-count' in properties.headers:
+        delivery_count = properties.headers['x-delivery-count']
+
+    return delivery_count
+
+
 class Consumer(AsyncConsumer):
 
     def on_message(self, unused_channel, basic_deliver, properties, body):
-        logger.info('Received message', delivery_tag=basic_deliver.delivery_tag, app_id=properties.app_id, body=body)
+        logger.info('Received message', delivery_tag=basic_deliver.delivery_tag, app_id=properties.app_id, body=body.decode("utf-8"))
+
+        delivery_count = get_delivery_count_from_properties(properties)
+        delivery_count += 1
+
         try:
             mongo_id = body.decode("utf-8")
             document = get_doc_from_store(mongo_id)
 
             processor = self.get_processor(document)
-            if processor.process():
-                self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+
+            if processor:
+                processed_ok = processor.process()
+
+                if processed_ok:
+                    self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+                else:
+                    if delivery_count == settings.QUEUE_MAX_MESSAGE_DELIVERIES:
+                        logger.error("Reached maximum number of retries", tx_id=processor.tx_id, delivery_count=delivery_count, message=mongo_id)
+                        self.reject_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+                    else:
+                        if publish_to_retry_queue(body, delivery_count):
+                            logger.info("Published to retry queue", tx_id=processor.tx_id, queue=settings.RABBIT_DELAY_QUEUE, delivery_count=delivery_count)
+                            self.reject_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+                        else:
+                            logger.error("Failed to publish to retry queue", tx_id=processor.tx_id, queue=settings.RABBIT_DELAY_QUEUE)
 
         except Exception as e:
             logger.error("ResponseProcessor failed", exception=e, tx_id=processor.tx_id)

--- a/app/helpers/request_helper.py
+++ b/app/helpers/request_helper.py
@@ -1,5 +1,6 @@
 from app.settings import logger, session, SDX_SEQUENCE_URL, SDX_STORE_URL
 from requests.packages.urllib3.exceptions import MaxRetryError
+from requests.exceptions import ConnectionError
 
 
 def remote_call(url, json=None):
@@ -17,13 +18,15 @@ def remote_call(url, json=None):
     except MaxRetryError:
         logger.error("Max retries exceeded (5)", request_url=url)
         return False
+    except ConnectionError:
+        logger.error("Connection error", request_url=url)
+        return False
 
 
 def response_ok(response):
     if response.status_code == 200:
         logger.info("Returned from service", request_url=response.url, status_code=response.status_code)
         return True
-
     else:
         logger.error("Returned from service", request_url=response.url, status_code=response.status_code)
         return False

--- a/app/processors/common_software_processor.py
+++ b/app/processors/common_software_processor.py
@@ -12,7 +12,7 @@ class CommonSoftwareProcessor(SurveyProcessor):
 
     def transform(self):
         response = remote_call(self.get_url(), json=self.survey)
-        if not response_ok(response):
+        if not response or not response_ok(response):
             return None
 
         return response.content

--- a/app/settings.py
+++ b/app/settings.py
@@ -28,7 +28,12 @@ FTP_FOLDER = os.getenv('FTP_FOLDER', '/')
 FTP_HEARTBEAT_FOLDER = os.getenv('FTP_HEARTBEAT_FOLDER', '/heartbeat')
 
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'sdx-survey-notifications')
+RABBIT_DELAY_QUEUE = os.getenv('RABBIT_DELAY_QUEUE', 'sdx-delayed-survey-notifications')
 RABBIT_QUEUE_TESTFORM = os.getenv('RABBIT_QUEUE_TESTFORM', 'sdx-testform')
+RABBIT_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', 'message')
+
+QUEUE_RETRY_DELAY_IN_MS = 20000
+QUEUE_MAX_MESSAGE_DELIVERIES = 3
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),

--- a/app/settings.py
+++ b/app/settings.py
@@ -6,7 +6,7 @@ from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: sdx-downstream: %(message)s"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
 
 logging.basicConfig(level=LOGGING_LEVEL, format=LOGGING_FORMAT)
 logger = wrap_logger(logging.getLogger(__name__))

--- a/app/settings.py
+++ b/app/settings.py
@@ -28,7 +28,7 @@ FTP_FOLDER = os.getenv('FTP_FOLDER', '/')
 FTP_HEARTBEAT_FOLDER = os.getenv('FTP_HEARTBEAT_FOLDER', '/heartbeat')
 
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'sdx-survey-notifications')
-RABBIT_DELAY_QUEUE = os.getenv('RABBIT_DELAY_QUEUE', 'sdx-delayed-survey-notifications')
+RABBIT_DELAY_QUEUE = os.getenv('RABBIT_DELAY_QUEUE', 'sdx-survey-notifications_delay')
 RABBIT_QUEUE_TESTFORM = os.getenv('RABBIT_QUEUE_TESTFORM', 'sdx-testform')
 RABBIT_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', 'message')
 


### PR DESCRIPTION
**Changes**

Uses a dead letter queue with a ttl on the messages to provide delayed retries functionality. See
http://stackoverflow.com/questions/17014584/how-to-create-a-delayed-queue-in-rabbitmq.
Also uses a 'x-delivery-count' header to keep track of how many times a message has been attempted and limit the number of attempts at re-processing.

Note that we still don't consider whether an error is retry-able or not - we just naively attempt to re-process a message up to three times. That will need to be done in a future pull request.

NB. I've also added a catch for a connection error which occurs if the service we're attempting to connect to service which is down - this surfaced when trying to check through killing the transform service during testing.

**How to test**
- Run the sdx-compose setup
- Submit a survey and ensure outputs are generated
- Stop sdx-transform-cs
- Check logs or rabbitmq web UI to see messages written to the sdx-survey-delayed-notifications queue and after a - 20 second delay moving back to the sdx-survey-notifications queue (which sdx-downstream) then picks up again.
- Verify that 3 attempts are made at processing the message.

**Who can test**

Anyone but @iwootten