### PR TITLE
Remove reject on max retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Fix [#23](https://github.com/ONSdigital/sdx-downstream/issues/23) by removing redundant census processor - now lives under [sdx-downstream-ctp](https://github.com/ONSdigital/sdx-downstream-ctp)
   - Update python library '_requests_': `2.10.0` -> `2.12.4`
   - Update docker base image to use [onsdigital/flask-crypto-queue](https://hub.docker.com/r/onsdigital/flask-crypto-queue/)
+  - Remove reject on max retries. Stops message being rejected if endpoint is down for prolonged period
 
 ### 1.0.1 2016-11-10
   - Fix [#16](https://github.com/ONSdigital/sdx-downstream/issues/16) remove rabbit queue connection details from logs

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -2,15 +2,6 @@ from app.settings import logger
 from app.async_consumer import AsyncConsumer
 from app.helpers.request_helper import get_doc_from_store
 from app.processors.common_software_processor import CommonSoftwareProcessor
-from app import settings
-
-
-def get_delivery_count_from_properties(properties):
-    delivery_count = 0
-    if properties.headers and 'x-delivery-count' in properties.headers:
-        delivery_count = properties.headers['x-delivery-count']
-
-    return delivery_count
 
 
 class Consumer(AsyncConsumer):
@@ -18,23 +9,15 @@ class Consumer(AsyncConsumer):
     def on_message(self, unused_channel, basic_deliver, properties, body):
         logger.info('Received message', delivery_tag=basic_deliver.delivery_tag, app_id=properties.app_id, body=body.decode("utf-8"))
 
-        delivery_count = get_delivery_count_from_properties(properties)
-        delivery_count += 1
-
         try:
             mongo_id = body.decode("utf-8")
             document = get_doc_from_store(mongo_id)
 
             processor = CommonSoftwareProcessor(logger, document)
 
-            if processor:
-                processed_ok = processor.process()
-
-                if processed_ok:
-                    self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
-                elif delivery_count == settings.QUEUE_MAX_MESSAGE_DELIVERIES:
-                    logger.error("Reached maximum number of retries", tx_id=processor.tx_id, delivery_count=delivery_count, message=mongo_id)
-                    self.reject_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+            processed_ok = processor.process()
+            if processed_ok:
+                self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
 
         except Exception as e:
             logger.error("ResponseProcessor failed", exception=e, tx_id=processor.tx_id)

--- a/app/settings.py
+++ b/app/settings.py
@@ -29,8 +29,6 @@ FTP_HEARTBEAT_FOLDER = os.getenv('FTP_HEARTBEAT_FOLDER', '/heartbeat')
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'sdx-survey-notifications')
 RABBIT_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', 'message')
 
-QUEUE_MAX_MESSAGE_DELIVERIES = 3
-
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),
     port=os.getenv('RABBITMQ_PORT', 5672),


### PR DESCRIPTION
Allow retrying if endpoint down for a prolonged period.

``QUEUE_MAX_MESSAGE_DELIVERIES`` env var no longer required.