### PR TITLE
Fix getting of tx_id in exception

### DIFF
--- a/app/consumer.py
+++ b/app/consumer.py
@@ -27,7 +27,7 @@ class Consumer(AsyncConsumer):
                 self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
 
         except Exception as e:
-            logger.error("ResponseProcessor failed", exception=e, tx_id=processor.tx_id)
+            logger.error("ResponseProcessor failed", exception=e, tx_id=document['tx_id'])
 
 
 def main():


### PR DESCRIPTION
Changed from getting from 'processor' in case exception occurs before the processor has been instantiated.