### PR TITLE
Feature/remove sdx home

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.4"
 install:
+  - make clean
   - make build
   - pip install codecov
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Change all instances of ADD to COPY in Dockerfile
+  - Remove use of SDX_HOME variable in makefile
 
 ### 2.1.0 2017-07-10
   - Log tx_id for FTP successes and failures

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,18 @@
-dev: check-env
-	cd .. && pip3 uninstall -y sdx-common && pip3 install -I ./sdx-common
-	pip3 install -r requirements.txt
-
 build:
-	git clone https://github.com/ONSdigital/sdx-common.git
+	git clone -b 0.7.0 https://github.com/ONSdigital/sdx-common.git
 	pip3 install ./sdx-common
 	pip3 install -r requirements.txt
 	rm -rf sdx-common
+
+dev:
+	cd .. && pip3 uninstall -y sdx-common && pip3 install -I ./sdx-common
+	pip3 install -r requirements.txt
+
 
 test:
 	pip3 install -r test_requirements.txt
 	flake8 --exclude ./lib/*
 	python3 -m unittest tests/*.py
 
-check-env:
-	ifeq ($(SDX_HOME),)
-		$(error SDX_HOME is not set)
-	endif
+clean:
+	rm -rf ./sdx-common


### PR DESCRIPTION
## What? and Why?
`SDX_HOME` is not required when building service (only used by docker compose version) and breaks the build if not present.

Removes `SDX_HOME` from the makefile to allow it to run. Also corrects order of targets in makefile so that `build` is default

Supersedes #61 