### PR TITLE
Remove pika set log level

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,6 @@ def run():
     logging.basicConfig(format=app.settings.LOGGING_FORMAT,
                         datefmt="%Y-%m-%dT%H:%M:%S",
                         level=app.settings.LOGGING_LEVEL)
-    logging.getLogger('pika').setLevel(logging.INFO)
     logging.getLogger('sdc.rabbit').setLevel(logging.INFO)
 
     message_processor = MessageProcessor()


### PR DESCRIPTION
## What? and Why?
> What does this pull request change/fix? Why was it necessary?
Removed setting log level for pika logger as it was causing problems picking up logs in splunk.


## Checklist
  - [ ] CHANGELOG.md updated? (if required)
