### PR TITLE
Removing support for heartbeat survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Removed ability to store heartbeat in a different folder
   - Refactored cora_processor , common_software_processor and message_processor to make them dryer
 
 ### 3.3.0 2017-11-21

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It's also possible to install within a container using docker. From the sdx-down
 
 ## Configuration
 
-The following envioronment variables can be set:
+The following environment variables can be set:
 
 | Environment Variable    | Default                               | Description
 |-------------------------|---------------------------------------|----------------
@@ -31,7 +31,6 @@ The following envioronment variables can be set:
 | FTP_USER                | _none_                                | User for FTP account if required
 | FTP_PASS                | _none_                                | Password for FTP account if required
 | FTP_FOLDER              | `/`                                   | FTP folder
-| FTP_HEARTBEAT_FOLDER    | `/heartbeat`                          | FTP heartbeat folder
 | RABBIT_QUEUE            | `sdx-cs-survey-notifications`         | Rabbit queue name
 | RABBIT_EXCHANGE         | `message`                             | RabbitMQ exchange to use
 

--- a/app/processors/processor_base.py
+++ b/app/processors/processor_base.py
@@ -19,7 +19,7 @@ class Processor:
         """call transform and error if needed"""
         transformed = self._transform()
 
-        delivered = self.ftp.unzip_and_deliver(self._get_ftp_folder(self.survey), transformed)
+        delivered = self.ftp.unzip_and_deliver(settings.FTP_FOLDER, transformed)
 
         if not delivered:
             self.logger.error("Failed to deliver zip to ftp")
@@ -64,11 +64,3 @@ class Processor:
         if sequence_no is None:
             raise RetryableError("Failed to get sequence number")
         return sequence_no
-
-    @staticmethod
-    def _get_ftp_folder(survey):
-        """return the destination folder as a string """
-        if 'heartbeat' in survey and survey['heartbeat'] is True:
-            return settings.FTP_HEARTBEAT_FOLDER
-
-        return settings.FTP_FOLDER

--- a/app/settings.py
+++ b/app/settings.py
@@ -64,7 +64,6 @@ FTP_HOST = _get_value('FTP_HOST', 'pure-ftpd')
 FTP_USER = os.getenv('FTP_USER')
 FTP_PASS = os.getenv('FTP_PASS')
 FTP_FOLDER = '/'
-FTP_HEARTBEAT_FOLDER = '/heartbeat'
 
 SDX_STORE_URL = _get_value("SDX_STORE_URL", "http://sdx-store:5000")
 SDX_TRANSFORM_CS_URL = _get_value("SDX_TRANSFORM_CS_URL", "http://sdx-transform-cs:5000")

--- a/tests/test_cora_processor.py
+++ b/tests/test_cora_processor.py
@@ -5,7 +5,6 @@ import json
 import logging
 from structlog import wrap_logger
 from app.processors.cora_processor import CoraProcessor
-from app.settings import FTP_HEARTBEAT_FOLDER
 from tests.test_data import cora_survey
 from requests import Response
 from app.helpers.sdxftp import SDXFTP
@@ -97,7 +96,3 @@ class TestCoraProcessor(unittest.TestCase):
         with self.assertLogs(level='ERROR') as cm:
             self.processor = CoraProcessor(logger, survey, ftpconn)
         self.assertIn("Failed to get metadata", cm[0][0].message)
-
-    def test_get_ftp_folder_returns_heartbeat_folder_for_heartbeat_survey(self):
-        folder = self.processor._get_ftp_folder({"heartbeat": True})
-        self.assertEquals(folder, FTP_HEARTBEAT_FOLDER)


### PR DESCRIPTION
## What? and Why?
> Removes support for heartbeat service, not used and would cause production issues if it was.

## Checklist
  - CHANGELOG.md updated 
