### PR TITLE
Removing second rabbit host for move to AWS corp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Remove second rabbit host
 
 ### 3.5.0 2018-01-17
   - Add heartbeat interval to rabbit mq url

--- a/app/settings.py
+++ b/app/settings.py
@@ -29,8 +29,7 @@ def parse_vcap_services():
     parsed_vcap_services = json.loads(vcap_services)
     rabbit_config = parsed_vcap_services.get('rabbitmq')
     rabbit_url = rabbit_config[0].get('credentials').get('uri') + HEARTBEAT_INTERVAL
-    rabbit_url2 = rabbit_config[1].get('credentials').get('uri') + HEARTBEAT_INTERVAL if len(rabbit_config) > 1 else rabbit_url
-    return rabbit_url, rabbit_url2
+    return rabbit_url
 
 
 def parse_non_vcap_services():
@@ -42,22 +41,15 @@ def parse_non_vcap_services():
         vhost=_get_value('RABBITMQ_DEFAULT_VHOST', '%2f')
     ) + HEARTBEAT_INTERVAL
 
-    rabbit_url2 = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
-        hostname=_get_value('RABBITMQ_HOST2', 'rabbit'),
-        port=_get_value('RABBITMQ_PORT2', 5672),
-        user=_get_value('RABBITMQ_DEFAULT_USER', 'rabbit'),
-        password=_get_value('RABBITMQ_DEFAULT_PASS', 'rabbit'),
-        vhost=_get_value('RABBITMQ_DEFAULT_VHOST', '%2f')
-    ) + HEARTBEAT_INTERVAL
-    return rabbit_url, rabbit_url2
+    return rabbit_url
 
 
 if os.getenv("CF_DEPLOYMENT", False):
-    RABBIT_URL, RABBIT_URL2 = parse_vcap_services()
+    RABBIT_URL = parse_vcap_services()
 else:
-    RABBIT_URL, RABBIT_URL2 = parse_non_vcap_services()
+    RABBIT_URL = parse_non_vcap_services()
 
-RABBIT_URLS = [RABBIT_URL, RABBIT_URL2]
+RABBIT_URLS = [RABBIT_URL]
 RABBIT_QUEUE = 'sdx-survey-notification-durable'
 RABBIT_EXCHANGE = 'message'
 RABBIT_QUARANTINE_QUEUE = os.getenv('RABBIT_QUARANTINE_QUEUE', 'sdx-downstream-quarantine')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -31,10 +31,9 @@ class TestNoBatchTransformService(unittest.TestCase):
             settings._get_value("SOME_UNKNOWN_ENV", "")
 
     def test_parse_vcap_services(self):
-        rabbit_url1, rabbit_url2 = settings.parse_vcap_services()
-        self.assertEqual("amqp://user:password@168.0.0.1:5672/example_vhost?heartbeat_interval=5", rabbit_url1)
-        self.assertEqual("amqp://user:password@168.0.0.1:5672/example_vhost?heartbeat_interval=5", rabbit_url2)
+        rabbit_url = settings.parse_vcap_services()
+        self.assertEqual("amqp://user:password@168.0.0.1:5672/example_vhost?heartbeat_interval=5", rabbit_url)
 
     def test_parse_non_vcap_services(self):
-        rabbit_url1, rabbit_url2 = settings.parse_non_vcap_services()
-        self.assertEqual('amqp://User:Password@Host:Port/VHost?heartbeat_interval=5', rabbit_url1)
+        rabbit_url = settings.parse_non_vcap_services()
+        self.assertEqual('amqp://User:Password@Host:Port/VHost?heartbeat_interval=5', rabbit_url)


### PR DESCRIPTION
## What? and Why?
Remove the second rabbit host url in preparation of the move to AWS corp where there is a load balance in front of the rabbit cluster

## Checklist
  - [x] CHANGELOG.md updated? (if required)
