### PR TITLE
Add tx_id to ftp logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add tx_id to ftp log lines
   - Add reprocessing scripts to repo
   - Add log with version on startup
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,7 @@
 import logging
-from structlog import wrap_logger
+import structlog
+from structlog.stdlib import LoggerFactory
+from structlog.threadlocal import wrap_dict
 
 from sdc.rabbit import MessageConsumer
 from sdc.rabbit import QueuePublisher
@@ -15,7 +17,9 @@ def run():
 
     logging.getLogger('sdc.rabbit').setLevel(logging.INFO)
 
-    logger = wrap_logger(logging.getLogger(__name__))
+    # These structlog settings allow bound fields to persist between classes
+    structlog.configure(logger_factory=LoggerFactory(), context_class=wrap_dict(dict))
+    logger = structlog.getLogger()
 
     logger.info('Starting SDX Downstream', version=__version__)
 

--- a/app/processors/common_software_processor.py
+++ b/app/processors/common_software_processor.py
@@ -4,5 +4,5 @@ from app.processors.processor_base import Processor
 
 class CommonSoftwareProcessor(Processor):
 
-    def __init__(self, logger, survey, ftpconn):
-        super().__init__(logger, survey, ftpconn, settings.SDX_TRANSFORM_CS_URL, 'common-software')
+    def __init__(self, survey, ftpconn):
+        super().__init__(survey, ftpconn, settings.SDX_TRANSFORM_CS_URL, 'common-software')

--- a/app/processors/cora_processor.py
+++ b/app/processors/cora_processor.py
@@ -4,5 +4,5 @@ from app.processors.processor_base import Processor
 
 class CoraProcessor(Processor):
 
-    def __init__(self, logger, survey, ftpconn):
-        super().__init__(logger, survey, ftpconn, settings.SDX_TRANSFORM_CORA_URL, 'cora')
+    def __init__(self, survey, ftpconn):
+        super().__init__(survey, ftpconn, settings.SDX_TRANSFORM_CORA_URL, 'cora')

--- a/tests/test_common_software_processor.py
+++ b/tests/test_common_software_processor.py
@@ -1,24 +1,23 @@
-import unittest
-import mock
-from unittest.mock import MagicMock
 import json
-import logging
-from structlog import wrap_logger
-from app.processors.common_software_processor import CommonSoftwareProcessor
-from tests.test_data import common_software_survey
+import mock
+import unittest
+from unittest.mock import MagicMock
+
 from requests import Response
-from app.helpers.sdxftp import SDXFTP
 from sdc.rabbit.exceptions import QuarantinableError, RetryableError
 
-logger = wrap_logger(logging.getLogger(__name__))
-ftpconn = SDXFTP(logger, "", "", "")
+from app.helpers.sdxftp import SDXFTP
+from app.processors.common_software_processor import CommonSoftwareProcessor
+from tests.test_data import common_software_survey
+
+ftpconn = SDXFTP("", "", "")
 
 
 class TestCommonSoftwareProcessor(unittest.TestCase):
 
     def setUp(self):
         survey = json.loads(common_software_survey)
-        self.processor = CommonSoftwareProcessor(logger, survey, ftpconn)
+        self.processor = CommonSoftwareProcessor(survey, ftpconn)
         self.processor.ftp.unzip_and_deliver = MagicMock(return_value=True)
 
     @staticmethod

--- a/tests/test_message_processor.py
+++ b/tests/test_message_processor.py
@@ -1,8 +1,13 @@
 import json
-import unittest
-import logging
 import mock
-from structlog import wrap_logger
+import logging
+import unittest
+
+import structlog
+from structlog.stdlib import LoggerFactory
+from structlog.threadlocal import wrap_dict
+
+from app import settings
 from app.processors.message_processor import MessageProcessor
 from app.processors.cora_processor import CoraProcessor
 from app.processors.common_software_processor import CommonSoftwareProcessor
@@ -12,8 +17,14 @@ from tests.test_data import common_software_survey, cora_survey
 class TestMessageProcessor(unittest.TestCase):
 
     def setUp(self):
-        self.logger = wrap_logger(logging.getLogger(__name__))
-        self.message_processor = MessageProcessor(logger=self.logger)
+        logging.basicConfig(format=settings.LOGGING_FORMAT,
+                            datefmt="%Y-%m-%dT%H:%M:%S",
+                            level=settings.LOGGING_LEVEL)
+
+        logging.getLogger('sdc.rabbit').setLevel(logging.INFO)
+
+        structlog.configure(logger_factory=LoggerFactory(), context_class=wrap_dict(dict))
+        self.message_processor = MessageProcessor()
 
     def test_message_processor_logging_common_software(self):
 


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/wDEKWpUM/2433-add-txid-to-sdxftp-log-lines

Needed to add tx_id of submission to the ftp part of downstream to help in diagnosing ops issues.

## How to test
Fire up console and put any non lms submission though.  The Delivering/Delivered binary file to FTP lines should have a tx_id

## Checklist
  - [x] CHANGELOG.md updated? (if required)
