### PR TITLE
Fix reprocessing script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
   - CORA submissions now go to sdx-transform-cs. sdx-transform-cs now handles transformations for all surveys as opposed
 to having separate services to handle different types.
+  - Fix newline bug in reprocessing script
 
 ### 3.8.0 2018-12-12
   - Added processor to handle surveys that go to CORD (currently only e-commerce)

--- a/scripts/reprocess.py
+++ b/scripts/reprocess.py
@@ -19,6 +19,8 @@ if __name__ == "__main__":
         sys.exit("No tx_ids in file, exiting script")
 
     for tx_id in lines:
+        # Remove newline character at the end of the tx_id (if present)
+        tx_id = tx_id.rstrip()
         print("About to put {} on the queue".format(tx_id))
         try:
             publisher.publish_message(tx_id, headers={'tx_id': tx_id})


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/Y5IIFsgN/674-fix-reprocess-script-in-sdx-downstream

Newline characters at the end of each tx_id was breaking it as the newline character was being included in the search (i.e., searching for '123-456\n' as opposed to '123-456')
This PR strips it off the end if it's there.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
