### PR TITLE
Investigate multiple different txids in sdx downstream lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+  - Fix issue where the previous submissions values (tx_id, ru_ref, user_id) were still bound at the start of a new submission
+  - Upgrade urllib3 package to fix security issue
 
 ### 3.9.1 2019-02-19
   - Fix security issue and update packages

--- a/app/processors/message_processor.py
+++ b/app/processors/message_processor.py
@@ -16,7 +16,6 @@ class MessageProcessor:
         self.cord_surveys = settings.CORD_SURVEYS
 
     def process(self, msg, tx_id):
-
         if tx_id is None:
             tx_id = msg
 
@@ -30,6 +29,9 @@ class MessageProcessor:
             processor.process()
             processor.logger.info("Processed successfully")
 
+            # If we don't unbind these fields, their current value will be retained for the next
+            # submission.  This leads to incorrect values being logged out in the bound fields.
+            self.logger = self.logger.unbind("tx_id", "ru_ref", "user_id")
         except KeyError:
             self.logger.error("No survey ID in document")
 

--- a/app/processors/processor_base.py
+++ b/app/processors/processor_base.py
@@ -53,10 +53,6 @@ class Processor:
             except KeyError:
                 self.logger.error("Failed to get metadata")
 
-            if 'tx_id' in self.survey:
-                self.tx_id = self.survey['tx_id']
-                self.logger = self.logger.bind(tx_id=self.tx_id)
-
     @staticmethod
     def _get_sequence_number():
         """return the sequence number else raise a Retryable Error"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,9 @@ idna==2.8 \
 certifi==2018.11.29 \
     --hash=sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7 \
     --hash=sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033
-urllib3==1.24.1 \
-    --hash=sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39 \
-    --hash=sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22
+urllib3==1.24.2 \
+    --hash=sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0 \
+    --hash=sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3
 chardet==3.0.4 \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae


### PR DESCRIPTION
## What? and Why?
There was a bug where every submission after the first would have the previous submissions tx_id, ru_ref and user_id in the logs between the start and after the decryption. After the decryption, the correct one became bound. This fixes that issue.

Additionally updates urllib3 to fix a security vulnerability.

## How to test
- Check out master
- Put through 2 submissions.  You'll notice on the second submission there are references to the first submissions tx_id, user_id and ru_ref in the first few lines (around the time it's going to sdx-store)
- Check this branch out
- Put through 2 more submissions and notice that the incorrect data is not there anymore.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
