### PR TITLE
1060 remove references to transform cora

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ### Unreleased
-
-### Unreleased 
+  - removed reference to transform_cora service
   - Reverted to default heartbeat
 
 ### 3.10.0 2019-06-20

--- a/app/helpers/request_helper.py
+++ b/app/helpers/request_helper.py
@@ -30,11 +30,7 @@ def service_name(url=None):
             return 'SDX_STORE'
         elif 'sequence' in parts:
             return 'SDX_SEQUENCE'
-        elif 'common-software' in parts:
-            return 'SDX_TRANSFORM_CS'
-        elif 'cord' in parts:
-            return 'SDX_TRANSFORM_CS'
-        elif 'cora' in parts:
+        elif 'common-software' in parts or 'cord' in parts or 'cora' in parts:  # easier to read than any()
             return 'SDX_TRANSFORM_CS'
         else:
             return None
@@ -47,14 +43,11 @@ def remote_call(url, json=None):
 
     try:
         logger.info("Calling service", request_url=url, service=service)
-        response = None
 
         if json:
-            response = session.post(url, json=json)
-        else:
-            response = session.get(url)
+            return session.post(url, json=json)
 
-        return response
+        return session.get(url)
 
     except MaxRetryError:
         logger.error("Max retries exceeded", request_url=url)
@@ -76,25 +69,25 @@ def response_ok(response):
                     status=response.status_code,
                     service=service,
                     )
-        raise QuarantinableError("Not Found response returned from {}".format(service))
+        raise QuarantinableError(f"Not Found response returned from {service}")
     elif 400 <= response.status_code < 500:
         logger.info("Bad Request response from service",
                     request_url=response.url,
                     status=response.status_code,
                     service=service,
                     )
-        raise QuarantinableError("Bad Request response from {}".format(service))
+        raise QuarantinableError(f"Bad Request response from {service}")
 
     logger.info("Bad response from service",
                 request_url=response.url,
                 status=response.status_code,
                 service=service,
                 )
-    raise RetryableError("Bad response from {}".format(service))
+    raise RetryableError(f"Bad response from {service}")
 
 
 def get_sequence_no():
-    sequence_url = "{0}/sequence".format(SDX_SEQUENCE_URL)
+    sequence_url = f"{SDX_SEQUENCE_URL}/sequence"
     response = remote_call(sequence_url)
 
     if response_ok(response):
@@ -103,7 +96,7 @@ def get_sequence_no():
 
 def get_doc_from_store(tx_id):
     logger.info("About to get document from store")
-    store_url = "{0}/responses/{1}".format(SDX_STORE_URL, tx_id)
+    store_url = f"{SDX_STORE_URL}/responses/{tx_id}"
     response = remote_call(store_url)
 
     if response_ok(response):

--- a/app/processors/common_software_processor.py
+++ b/app/processors/common_software_processor.py
@@ -1,8 +1,0 @@
-from app import settings
-from app.processors.processor_base import Processor
-
-
-class CommonSoftwareProcessor(Processor):
-
-    def __init__(self, survey, ftpconn):
-        super().__init__(survey, ftpconn, settings.SDX_TRANSFORM_CS_URL, 'common-software')

--- a/app/processors/cora_processor.py
+++ b/app/processors/cora_processor.py
@@ -1,8 +1,0 @@
-from app import settings
-from app.processors.processor_base import Processor
-
-
-class CoraProcessor(Processor):
-
-    def __init__(self, survey, ftpconn):
-        super().__init__(survey, ftpconn, settings.SDX_TRANSFORM_CS_URL, 'cora')

--- a/app/processors/cord_processor.py
+++ b/app/processors/cord_processor.py
@@ -1,8 +1,0 @@
-from app import settings
-from app.processors.processor_base import Processor
-
-
-class CordProcessor(Processor):
-
-    def __init__(self, survey, ftpconn):
-        super().__init__(survey, ftpconn, settings.SDX_TRANSFORM_CS_URL, 'cord')

--- a/app/processors/message_processor.py
+++ b/app/processors/message_processor.py
@@ -1,19 +1,16 @@
 from structlog import get_logger
 
+
 from app.helpers.request_helper import get_doc_from_store
-from app.processors.common_software_processor import CommonSoftwareProcessor
-from app.processors.cora_processor import CoraProcessor
-from app.processors.cord_processor import CordProcessor
-from app import settings
+from app.processors.transform_processor import TransformProcessor
 from app.helpers.sdxftp import SDXFTP
+from app import settings
 
 
 class MessageProcessor:
     def __init__(self):
         self.logger = get_logger()
-        self._ftp = SDXFTP(settings.FTP_HOST, settings.FTP_USER, settings.FTP_PASS)
-        self.cora_surveys = settings.CORA_SURVEYS
-        self.cord_surveys = settings.CORD_SURVEYS
+        self.ftp = SDXFTP(settings.FTP_HOST, settings.FTP_USER, settings.FTP_PASS)
 
     def process(self, msg, tx_id):
         if tx_id is None:
@@ -25,22 +22,12 @@ class MessageProcessor:
         document = get_doc_from_store(tx_id)
 
         try:
-            processor = self._get_processor(document)
-            processor.process()
-            processor.logger.info("Processed successfully")
+            transform_processor = TransformProcessor(document, self.ftp)
+            transform_processor.process()
+            self.logger.info("Processed successfully")
 
             # If we don't unbind these fields, their current value will be retained for the next
             # submission.  This leads to incorrect values being logged out in the bound fields.
             self.logger = self.logger.unbind("tx_id", "ru_ref", "user_id")
         except KeyError:
             self.logger.error("No survey ID in document")
-
-    def _get_processor(self, document):
-        """Processor factory that returns the correct processor based on the survey_id in the document"""
-
-        if document['survey_id'] in self.cora_surveys:
-            return CoraProcessor(document, self._ftp)
-        if document['survey_id'] in self.cord_surveys:
-            return CordProcessor(document, self._ftp)
-
-        return CommonSoftwareProcessor(document, self._ftp)

--- a/app/processors/processor_base.py
+++ b/app/processors/processor_base.py
@@ -34,7 +34,7 @@ class Processor:
         response = remote_call(endpoint, json=self.survey)
 
         if response_ok(response) and response.content is not None:
-            self.logger.info("{}:Successfully transformed".format(self.__class__.__name__))
+            self.logger.info(f"{self.__class__.__name__}:Successfully transformed")
             return response.content
 
         raise QuarantinableError("Response missing content")
@@ -42,7 +42,7 @@ class Processor:
     def _get_url(self):
         """Gets the transformer url"""
         sequence_no = Processor._get_sequence_number()
-        return "{0}/{1}/{2}".format(self._base_url, self._endpoint_name, sequence_no)
+        return f"{self._base_url}/{self._endpoint_name}/{sequence_no}"
 
     def _setup_logger(self):
         """Sets up the logger"""

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,7 +17,7 @@ def _get_value(key, default_value=None):
     """
     value = os.getenv(key, default_value)
     if not value:
-        logger.error("No value set for {}".format(key))
+        logger.error(f"No value set for {key}")
         raise ValueError()
     return value
 
@@ -59,7 +59,6 @@ FTP_FOLDER = '/'
 
 SDX_STORE_URL = _get_value("SDX_STORE_URL", "http://sdx-store:5000")
 SDX_TRANSFORM_CS_URL = _get_value("SDX_TRANSFORM_CS_URL", "http://sdx-transform-cs:5000")
-SDX_TRANSFORM_CORA_URL = _get_value("SDX_TRANSFORM_CORA_URL", "http://sdx-transform-cora:5000")
 SDX_SEQUENCE_URL = _get_value("SDX_SEQUENCE_URL", "http://sdx-sequence:5000")
 
 CORA_SURVEYS = ['144']

--- a/manifest-template.yml
+++ b/manifest-template.yml
@@ -11,7 +11,6 @@ applications:
     CF_DEPLOYMENT: True
     SDX_STORE_URL: http://sdx-store-SPACE.apps.devtest.onsclofo.uk
     SDX_TRANSFORM_CS_URL: http://sdx-transform-cs-SPACE.apps.devtest.onsclofo.uk
-    SDX_TRANSFORM_CORA_URL: http://sdx-transform-cora-SPACE.apps.devtest.onsclofo.uk
     SDX_SEQUENCE_URL:  http://sdx-sequence-SPACE.apps.devtest.onsclofo.uk
     FTP_HOST: FTPHOST
     FTP_USER: FTPUSER

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,6 @@ applications:
     CF_DEPLOYMENT: True
     SDX_STORE_URL: http://sdx-store.apps.devtest.onsclofo.uk
     SDX_TRANSFORM_CS_URL: http://sdx-transform-cs.apps.devtest.onsclofo.uk
-    SDX_TRANSFORM_CORA_URL: http://sdx-transform-cora.apps.devtest.onsclofo.uk
     SDX_SEQUENCE_URL:  http://sdx-sequence.apps.devtest.onsclofo.uk
     FTP_HOST: localhost
     FTP_USER: 'ons'

--- a/scripts/reprocess.py
+++ b/scripts/reprocess.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     for tx_id in lines:
         # Remove newline character at the end of the tx_id (if present)
         tx_id = tx_id.rstrip()
-        print("About to put {} on the queue".format(tx_id))
+        print(f"About to put {tx_id} on the queue")
         try:
             publisher.publish_message(tx_id, headers={'tx_id': tx_id})
         except PublishMessageError as e:

--- a/tests/processor_test_base.py
+++ b/tests/processor_test_base.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 from app.helpers.sdxftp import SDXFTP
 
+
 ftpconn = SDXFTP("", "", "")
 
 
@@ -19,11 +20,11 @@ class ProcessorTestBase:  # pylint: disable=no-member
         return response
 
     def test_transform(self):
-        with mock.patch('app.processors.processor_base.get_sequence_no') as seq_mock:
+        with mock.patch('app.processors.transform_processor.get_sequence_no') as seq_mock:
             seq_mock.return_value = '1001'
             response = self._get_response()
 
-            with mock.patch('app.processors.processor_base.remote_call') as call_mock:
+            with mock.patch('app.processors.transform_processor.remote_call') as call_mock:
 
                 # 500 something ary
                 response.status_code = 500
@@ -49,10 +50,10 @@ class ProcessorTestBase:  # pylint: disable=no-member
                     self.processor.process()
 
     def test_sequence(self):
-        with mock.patch('app.processors.processor_base.get_sequence_no') as seq_mock:
+        with mock.patch('app.processors.transform_processor.get_sequence_no') as seq_mock:
 
             response = self._get_response()
-            with mock.patch('app.processors.processor_base.remote_call') as call_mock:
+            with mock.patch('app.processors.transform_processor.remote_call') as call_mock:
                 call_mock.return_value = response
 
                 # Good return
@@ -65,11 +66,11 @@ class ProcessorTestBase:  # pylint: disable=no-member
                     self.processor.process()
 
     def test_ftp(self):
-        with mock.patch('app.processors.processor_base.get_sequence_no') as seq_mock:
+        with mock.patch('app.processors.transform_processor.get_sequence_no') as seq_mock:
             seq_mock.return_value = '1001'
 
             response = self._get_response()
-            with mock.patch('app.processors.processor_base.remote_call') as call_mock:
+            with mock.patch('app.processors.transform_processor.remote_call') as call_mock:
                 call_mock.return_value = response
 
                 # Good deliver

--- a/tests/test_common_software_processor.py
+++ b/tests/test_common_software_processor.py
@@ -7,7 +7,7 @@ from requests import Response
 from sdc.rabbit.exceptions import QuarantinableError, RetryableError
 
 from app.helpers.sdxftp import SDXFTP
-from app.processors.common_software_processor import CommonSoftwareProcessor
+from app.processors.transform_processor import TransformProcessor
 from tests.test_data import common_software_survey
 
 ftpconn = SDXFTP("", "", "")
@@ -17,7 +17,7 @@ class TestCommonSoftwareProcessor(unittest.TestCase):
 
     def setUp(self):
         survey = json.loads(common_software_survey)
-        self.processor = CommonSoftwareProcessor(survey, ftpconn)
+        self.processor = TransformProcessor(survey, ftpconn)
         self.processor.ftp.unzip_and_deliver = MagicMock(return_value=True)
 
     @staticmethod
@@ -28,11 +28,11 @@ class TestCommonSoftwareProcessor(unittest.TestCase):
         return response
 
     def test_transform(self):
-        with mock.patch('app.processors.processor_base.get_sequence_no') as seq_mock:
+        with mock.patch('app.processors.transform_processor.get_sequence_no') as seq_mock:
             seq_mock.return_value = '1001'
             response = self._get_response()
 
-            with mock.patch('app.processors.processor_base.remote_call') as call_mock:
+            with mock.patch('app.processors.transform_processor.remote_call') as call_mock:
 
                 # 500 something ary
                 response.status_code = 500
@@ -58,10 +58,10 @@ class TestCommonSoftwareProcessor(unittest.TestCase):
                     self.processor.process()
 
     def test_sequence(self):
-        with mock.patch('app.processors.processor_base.get_sequence_no') as seq_mock:
+        with mock.patch('app.processors.transform_processor.get_sequence_no') as seq_mock:
 
             response = self._get_response()
-            with mock.patch('app.processors.processor_base.remote_call') as call_mock:
+            with mock.patch('app.processors.transform_processor.remote_call') as call_mock:
                 call_mock.return_value = response
 
                 # Good return
@@ -74,11 +74,11 @@ class TestCommonSoftwareProcessor(unittest.TestCase):
                     self.processor.process()
 
     def test_ftp(self):
-        with mock.patch('app.processors.processor_base.get_sequence_no') as seq_mock:
+        with mock.patch('app.processors.transform_processor.get_sequence_no') as seq_mock:
             seq_mock.return_value = '1001'
 
             response = self._get_response()
-            with mock.patch('app.processors.processor_base.remote_call') as call_mock:
+            with mock.patch('app.processors.transform_processor.remote_call') as call_mock:
                 call_mock.return_value = response
 
                 # Good deliver

--- a/tests/test_cora_processor.py
+++ b/tests/test_cora_processor.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 from app import settings
 from app.helpers.sdxftp import SDXFTP
-from app.processors.cora_processor import CoraProcessor
+from app.processors.transform_processor import TransformProcessor
 from tests.test_data import cora_survey
 from tests.processor_test_base import ProcessorTestBase
 
@@ -27,11 +27,11 @@ class TestCoraProcessor(unittest.TestCase, ProcessorTestBase):
 
         structlog.configure(logger_factory=LoggerFactory(), context_class=wrap_dict(dict))
         survey = json.loads(cora_survey)
-        self.processor = CoraProcessor(survey, ftpconn)
+        self.processor = TransformProcessor(survey, ftpconn)
         self.processor.ftp.unzip_and_deliver = MagicMock(return_value=True)
 
     def test_if_no_metadata_error_is_logged(self):
-        survey = {"a key": "a value"}
+        survey = {"a key": "a value", "survey_id": "a_survey_id"}
         with self.assertLogs(level='ERROR') as cm:
-            self.processor = CoraProcessor(survey, ftpconn)
+            self.processor = TransformProcessor(survey, ftpconn)
         self.assertIn("Failed to get metadata", cm[0][0].message)

--- a/tests/test_cord_processor.py
+++ b/tests/test_cord_processor.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 from app import settings
 from app.helpers.sdxftp import SDXFTP
-from app.processors.cord_processor import CordProcessor
+from app.processors.transform_processor import TransformProcessor
 from tests.test_data import cord_survey
 from tests.processor_test_base import ProcessorTestBase
 
@@ -27,11 +27,11 @@ class TestCordProcessor(unittest.TestCase, ProcessorTestBase):
 
         structlog.configure(logger_factory=LoggerFactory(), context_class=wrap_dict(dict))
         survey = json.loads(cord_survey)
-        self.processor = CordProcessor(survey, ftpconn)
+        self.processor = TransformProcessor(survey, ftpconn)
         self.processor.ftp.unzip_and_deliver = MagicMock(return_value=True)
 
     def test_if_no_metadata_error_is_logged(self):
-        survey = {"a key": "a value"}
+        survey = {"a key": "a value", "survey_id": "a survey id"}
         with self.assertLogs(level='ERROR') as cm:
-            self.processor = CordProcessor(survey, ftpconn)
+            self.processor = TransformProcessor(survey, ftpconn)
         self.assertIn("Failed to get metadata", cm[0][0].message)

--- a/tests/test_message_processor.py
+++ b/tests/test_message_processor.py
@@ -9,8 +9,6 @@ from structlog.threadlocal import wrap_dict
 
 from app import settings
 from app.processors.message_processor import MessageProcessor
-from app.processors.cora_processor import CoraProcessor
-from app.processors.common_software_processor import CommonSoftwareProcessor
 from tests.test_data import common_software_survey, cora_survey
 
 
@@ -30,7 +28,7 @@ class TestMessageProcessor(unittest.TestCase):
 
         with mock.patch('app.processors.message_processor.get_doc_from_store') as get_doc_mock:
             get_doc_mock.return_value = json.loads(common_software_survey)
-            with mock.patch('app.processors.processor_base.Processor.process') as csp_mock:
+            with mock.patch('app.processors.transform_processor.TransformProcessor.process') as csp_mock:
                 with self.assertLogs(level='INFO') as cm:
 
                     csp_mock.return_value = None
@@ -45,7 +43,7 @@ class TestMessageProcessor(unittest.TestCase):
 
         with mock.patch('app.processors.message_processor.get_doc_from_store') as get_doc_mock:
             get_doc_mock.return_value = json.loads(cora_survey)
-            with mock.patch('app.processors.processor_base.Processor.process') as cora_mock:
+            with mock.patch('app.processors.transform_processor.TransformProcessor.process') as cora_mock:
                 with self.assertLogs(level='INFO') as cm:
 
                     cora_mock.return_value = None
@@ -56,23 +54,11 @@ class TestMessageProcessor(unittest.TestCase):
             self.assertIn("Received message", cm[0][0].message)
             self.assertIn("Processed successfully", cm[0][1].message)
 
-    def test_message_processor_selects_cora_for_cora_surveys(self):
-        response_data = json.loads(cora_survey)
-        processor = self.message_processor._get_processor(response_data)
-
-        self.assertIsInstance(processor, CoraProcessor)
-
-    def test_message_processor_selects_common_software_for_common_software_surveys(self):
-        response_data = json.loads(common_software_survey)
-        processor = self.message_processor._get_processor(response_data)
-
-        self.assertIsInstance(processor, CommonSoftwareProcessor)
-
     def test_message_processor_logs_error_if_KeyError_raised(self):
 
         with mock.patch('app.processors.message_processor.get_doc_from_store') as get_doc_mock:
             get_doc_mock.return_value = json.loads(cora_survey)
-            with mock.patch('app.processors.processor_base.Processor.process') as cora_mock:
+            with mock.patch('app.processors.transform_processor.TransformProcessor.process') as cora_mock:
                 with self.assertLogs(level='INFO') as cm:
 
                     cora_mock.side_effect = KeyError
@@ -87,7 +73,7 @@ class TestMessageProcessor(unittest.TestCase):
 
         with mock.patch('app.processors.message_processor.get_doc_from_store') as get_doc_mock:
             get_doc_mock.return_value = json.loads(cora_survey)
-            with mock.patch('app.processors.processor_base.Processor.process'):
+            with mock.patch('app.processors.transform_processor.TransformProcessor.process'):
                 with self.assertLogs(level='INFO') as cm:
                     self.message_processor.process("0f534ffc-9442-414c-b39f-a756b4adc6cb", None)
 

--- a/tests/test_transform_processor.py
+++ b/tests/test_transform_processor.py
@@ -1,0 +1,32 @@
+import json
+import unittest
+
+from app.processors.transform_processor import TransformProcessor
+from app.helpers.sdxftp import SDXFTP
+from tests.test_data import cora_survey, cord_survey, common_software_survey
+
+ftpconn = SDXFTP("", "", "")
+
+
+class TestTransformProcessor(unittest.TestCase):
+
+    def test_cora_endpoint_selected_for_cora_survey(self):
+        survey = json.loads(cora_survey)
+
+        sut = TransformProcessor(survey, ftpconn)
+
+        self.assertEqual(sut._endpoint_name, 'cora')
+
+    def test_cora_endpoint_selected_for_cord_survey(self):
+        survey = json.loads(cord_survey)
+
+        sut = TransformProcessor(survey, ftpconn)
+
+        self.assertEqual(sut._endpoint_name, 'cord')
+
+    def test_cora_endpoint_selected_for_common_software_survey(self):
+        survey = json.loads(common_software_survey)
+
+        sut = TransformProcessor(survey, ftpconn)
+
+        self.assertEqual(sut._endpoint_name, 'common-software')


### PR DESCRIPTION
## What? and Why?
Downstream still referred to the transform cora service. It now hits a cora endpoint on the transform_cs service.
Also changed some string formats to f strings

## Checklist
  - [y ] CHANGELOG.md updated? (if required)
