### PR TITLE
All surveys call 'transform' endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - All surveys call 'transform' endpoint
 
 ### 3.13.3 2020-05-21
   - Updated packages

--- a/app/processors/transform_processor.py
+++ b/app/processors/transform_processor.py
@@ -13,8 +13,6 @@ class TransformProcessor:
            ftp_conn: ftp connection , passed in for testing purposes
         """
         self._base_url = settings.SDX_TRANSFORM_CS_URL
-        self.cora_surveys = settings.CORA_SURVEYS
-        self.cord_surveys = settings.CORD_SURVEYS
 
         self.survey = survey
         self.tx_id = ""
@@ -23,7 +21,7 @@ class TransformProcessor:
         self._setup_logger()
 
         self.ftp = ftp_conn
-        self._endpoint_name = self._get_transformer_endpoint_name(survey)
+        self._endpoint_name = self._get_transformer_endpoint_name()
 
     def process(self):
         """call transform and error if needed"""
@@ -70,12 +68,7 @@ class TransformProcessor:
             raise RetryableError("Failed to get sequence number")
         return sequence_no
 
-    def _get_transformer_endpoint_name(self, survey):
-        """Returns the end point name based on the survey_id in the survey document"""
-
-        if survey['survey_id'] in self.cora_surveys:
-            return 'cora'
-        if survey['survey_id'] in self.cord_surveys:
-            return 'cord'
-
-        return 'common-software'
+    @staticmethod
+    def _get_transformer_endpoint_name():
+        """Returns the end point name"""
+        return 'transform'

--- a/app/settings.py
+++ b/app/settings.py
@@ -40,6 +40,3 @@ FTP_FOLDER = '/'
 SDX_STORE_URL = _get_value("SDX_STORE_URL", "http://sdx-store:5000")
 SDX_TRANSFORM_CS_URL = _get_value("SDX_TRANSFORM_CS_URL", "http://sdx-transform-cs:5000")
 SDX_SEQUENCE_URL = _get_value("SDX_SEQUENCE_URL", "http://sdx-sequence:5000")
-
-CORA_SURVEYS = ['144']
-CORD_SURVEYS = ['187']  # E-commerce

--- a/tests/test_transform_processor.py
+++ b/tests/test_transform_processor.py
@@ -15,18 +15,18 @@ class TestTransformProcessor(unittest.TestCase):
 
         sut = TransformProcessor(survey, ftpconn)
 
-        self.assertEqual(sut._endpoint_name, 'cora')
+        self.assertEqual(sut._endpoint_name, 'transform')
 
     def test_cora_endpoint_selected_for_cord_survey(self):
         survey = json.loads(cord_survey)
 
         sut = TransformProcessor(survey, ftpconn)
 
-        self.assertEqual(sut._endpoint_name, 'cord')
+        self.assertEqual(sut._endpoint_name, 'transform')
 
     def test_cora_endpoint_selected_for_common_software_survey(self):
         survey = json.loads(common_software_survey)
 
         sut = TransformProcessor(survey, ftpconn)
 
-        self.assertEqual(sut._endpoint_name, 'common-software')
+        self.assertEqual(sut._endpoint_name, 'transform')


### PR DESCRIPTION
## What? and Why?
> All calls to sdx-transform-cs now go through a single endpoint. This means that sdx-downstream no longer needs specific knowledge of the surveys to call transform

## Checklist
  - [x] CHANGELOG.md updated? (if required)
